### PR TITLE
PLATFORM-6395 fandom-auth: set session cookie for API flow login

### DIFF
--- a/selfservice/flow/login/hook.go
+++ b/selfservice/flow/login/hook.go
@@ -99,7 +99,10 @@ func (e *HookExecutor) PostLoginHook(w http.ResponseWriter, r *http.Request, a *
 	}
 
 	if a.Type == flow.TypeAPI {
-		if err := e.d.SessionPersister().CreateSession(r.Context(), s); err != nil {
+		// Fandom-start set session cookie for API flow login -> https://fandom.atlassian.net/browse/PLATFORM-6395
+		// https://fandom.atlassian.net/wiki/spaces/MOB/pages/1963163864/Fandom+Auth+in+mobile-app
+		if err := e.d.SessionManager().CreateAndIssueCookie(r.Context(), w, r, s); err != nil {
+		// Fandom-end
 			return errors.WithStack(err)
 		}
 		e.d.Audit().


### PR DESCRIPTION
https://fandom.atlassian.net/browse/PLATFORM-6395
https://fandom.atlassian.net/wiki/spaces/PLAT/pages/2152759522/Fandom+Auth+Mobile+Apps+API#Sign-in

Set session cookie after successful API flow login
Related pandora change https://github.com/Wikia/pandora/pull/11760