### PR TITLE
PLATFORM-6476 | Add form fields to pre-persists Login web_hook

### DIFF
--- a/selfservice/hook/web_hook.go
+++ b/selfservice/hook/web_hook.go
@@ -262,6 +262,9 @@ func (e *WebHook) ExecuteLoginPostHook(_ http.ResponseWriter, req *http.Request,
 		RequestUrl:     req.RequestURI,
 		Identity:       session.Identity,
 		HookType:       "LoginPostHook",
+		// fandom-start
+		Fields: req.Form,
+		// fandom-end
 	})
 }
 


### PR DESCRIPTION
## Description
To add eg. captcha validation on login forms, we need to pass form fields and values to web_hook context where it will be accessible.

## Who might be interested?
@Wikia/platform-team 