### PR TITLE
fix: add issuerURL for apple id (#2565)

### DIFF
--- a/selfservice/strategy/oidc/provider_apple.go
+++ b/selfservice/strategy/oidc/provider_apple.go
@@ -24,6 +24,7 @@ func NewProviderApple(
 	config *Configuration,
 	reg dependencies,
 ) *ProviderApple {
+	config.IssuerURL = "https://appleid.apple.com"
 	return &ProviderApple{
 		ProviderGenericOIDC: &ProviderGenericOIDC{
 			config: config,


### PR DESCRIPTION
## Links
* https://github.com/ory/kratos/issues/2558
* https://fandom.atlassian.net/browse/PLATFORM-7637

## Description
No issuer url was specified when using the Apple ID provider, this forced usersers to manually enter it in the provider config.

## Who might be interested?
@Wikia/platform-team 