### PR TITLE
PLATFORM-7673 | Allow AAL2 admin sessions with flag

### DIFF
--- a/internal/httpclient/README.md
+++ b/internal/httpclient/README.md
@@ -94,7 +94,7 @@ Class | Method | HTTP request | Description
 *V0alpha2Api* | [**AdminDeleteIdentitySessions**](docs/V0alpha2Api.md#admindeleteidentitysessions) | **Delete** /admin/identities/{id}/sessions | Calling this endpoint irrecoverably and permanently deletes and invalidates all sessions that belong to the given Identity.
 *V0alpha2Api* | [**AdminExtendSession**](docs/V0alpha2Api.md#adminextendsession) | **Patch** /admin/sessions/{id}/extend | Calling this endpoint extends the given session ID. If &#x60;session.earliest_possible_extend&#x60; is set it will only extend the session after the specified time has passed.
 *V0alpha2Api* | [**AdminGetIdentity**](docs/V0alpha2Api.md#admingetidentity) | **Get** /admin/identities/{id} | Get an Identity
-*V0alpha2Api* | [**AdminIdentitySession**](docs/V0alpha2Api.md#adminidentitysession) | **Get** /identities/{id}/session | Calling this endpoint issues a session for a given identity.
+*V0alpha2Api* | [**AdminIdentitySession**](docs/V0alpha2Api.md#adminidentitysession) | **Get** /admin/identities/{id}/session | Calling this endpoint issues a session for a given identity.
 *V0alpha2Api* | [**AdminListIdentities**](docs/V0alpha2Api.md#adminlistidentities) | **Get** /admin/identities | List Identities
 *V0alpha2Api* | [**AdminListIdentitySessions**](docs/V0alpha2Api.md#adminlistidentitysessions) | **Get** /admin/identities/{id}/sessions | This endpoint returns all sessions that belong to the given Identity.
 *V0alpha2Api* | [**AdminUpdateCredentials**](docs/V0alpha2Api.md#adminupdatecredentials) | **Put** /identities/{id}/credentials | Update Identity Credentials

--- a/internal/httpclient/api/openapi.yaml
+++ b/internal/httpclient/api/openapi.yaml
@@ -276,6 +276,56 @@ paths:
       summary: Update an Identity
       tags:
       - v0alpha2
+  /admin/identities/{id}/session:
+    get:
+      description: |-
+        This endpoint is useful for:
+
+        Issuing session or session token for a given identity without authenticating
+      operationId: adminIdentitySession
+      parameters:
+      - description: ID is the identity's ID.
+        explode: false
+        in: path
+        name: id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - description: |-
+          Upgrade is a boolean flag that decides, if session should be upgrade to the highest possible level.
+          If no value is provided, session returned is set with AAL1 level.
+        explode: true
+        in: query
+        name: upgrade
+        required: false
+        schema:
+          type: boolean
+        style: form
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/successfulAdminIdentitySession'
+          description: successfulAdminIdentitySession
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jsonError'
+          description: jsonError
+        "500":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/jsonError'
+          description: jsonError
+      security:
+      - oryAccessToken: []
+      summary: Calling this endpoint issues a session for a given identity.
+      tags:
+      - v0alpha2
   /admin/identities/{id}/sessions:
     delete:
       description: |-
@@ -690,46 +740,6 @@ paths:
                 $ref: '#/components/schemas/jsonError'
           description: jsonError
       summary: Update Identity Credentials
-      tags:
-      - v0alpha2
-  /identities/{id}/session:
-    get:
-      description: |-
-        This endpoint is useful for:
-
-        Issuing session or session token for a given identity without authenticating
-      operationId: adminIdentitySession
-      parameters:
-      - description: ID is the identity's ID.
-        explode: false
-        in: path
-        name: id
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/successfulAdminIdentitySession'
-          description: successfulAdminIdentitySession
-        "404":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/jsonError'
-          description: jsonError
-        "500":
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/jsonError'
-          description: jsonError
-      security:
-      - oryAccessToken: []
-      summary: Calling this endpoint issues a session for a given identity.
       tags:
       - v0alpha2
   /schemas:

--- a/internal/httpclient/api_v0alpha2.go
+++ b/internal/httpclient/api_v0alpha2.go
@@ -2176,6 +2176,12 @@ type V0alpha2ApiApiAdminIdentitySessionRequest struct {
 	ctx        context.Context
 	ApiService V0alpha2Api
 	id         string
+	upgrade    *bool
+}
+
+func (r V0alpha2ApiApiAdminIdentitySessionRequest) Upgrade(upgrade bool) V0alpha2ApiApiAdminIdentitySessionRequest {
+	r.upgrade = &upgrade
+	return r
 }
 
 func (r V0alpha2ApiApiAdminIdentitySessionRequest) Execute() (*SuccessfulAdminIdentitySession, *http.Response, error) {
@@ -2218,13 +2224,16 @@ func (a *V0alpha2ApiService) AdminIdentitySessionExecute(r V0alpha2ApiApiAdminId
 		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
 	}
 
-	localVarPath := localBasePath + "/identities/{id}/session"
+	localVarPath := localBasePath + "/admin/identities/{id}/session"
 	localVarPath = strings.Replace(localVarPath, "{"+"id"+"}", url.PathEscape(parameterToString(r.id, "")), -1)
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
+	if r.upgrade != nil {
+		localVarQueryParams.Add("upgrade", parameterToString(*r.upgrade, ""))
+	}
 	// to determine the Content-Type header
 	localVarHTTPContentTypes := []string{}
 

--- a/internal/httpclient/docs/V0alpha2Api.md
+++ b/internal/httpclient/docs/V0alpha2Api.md
@@ -11,7 +11,7 @@ Method | HTTP request | Description
 [**AdminDeleteIdentitySessions**](V0alpha2Api.md#AdminDeleteIdentitySessions) | **Delete** /admin/identities/{id}/sessions | Calling this endpoint irrecoverably and permanently deletes and invalidates all sessions that belong to the given Identity.
 [**AdminExtendSession**](V0alpha2Api.md#AdminExtendSession) | **Patch** /admin/sessions/{id}/extend | Calling this endpoint extends the given session ID. If &#x60;session.earliest_possible_extend&#x60; is set it will only extend the session after the specified time has passed.
 [**AdminGetIdentity**](V0alpha2Api.md#AdminGetIdentity) | **Get** /admin/identities/{id} | Get an Identity
-[**AdminIdentitySession**](V0alpha2Api.md#AdminIdentitySession) | **Get** /identities/{id}/session | Calling this endpoint issues a session for a given identity.
+[**AdminIdentitySession**](V0alpha2Api.md#AdminIdentitySession) | **Get** /admin/identities/{id}/session | Calling this endpoint issues a session for a given identity.
 [**AdminListIdentities**](V0alpha2Api.md#AdminListIdentities) | **Get** /admin/identities | List Identities
 [**AdminListIdentitySessions**](V0alpha2Api.md#AdminListIdentitySessions) | **Get** /admin/identities/{id}/sessions | This endpoint returns all sessions that belong to the given Identity.
 [**AdminUpdateCredentials**](V0alpha2Api.md#AdminUpdateCredentials) | **Put** /identities/{id}/credentials | Update Identity Credentials
@@ -534,7 +534,7 @@ Name | Type | Description  | Notes
 
 ## AdminIdentitySession
 
-> SuccessfulAdminIdentitySession AdminIdentitySession(ctx, id).Execute()
+> SuccessfulAdminIdentitySession AdminIdentitySession(ctx, id).Upgrade(upgrade).Execute()
 
 Calling this endpoint issues a session for a given identity.
 
@@ -554,10 +554,11 @@ import (
 
 func main() {
     id := "id_example" // string | ID is the identity's ID.
+    upgrade := true // bool | Upgrade is a boolean flag that decides, if session should be upgrade to the highest possible level. If no value is provided, session returned is set with AAL1 level. (optional)
 
     configuration := openapiclient.NewConfiguration()
     apiClient := openapiclient.NewAPIClient(configuration)
-    resp, r, err := apiClient.V0alpha2Api.AdminIdentitySession(context.Background(), id).Execute()
+    resp, r, err := apiClient.V0alpha2Api.AdminIdentitySession(context.Background(), id).Upgrade(upgrade).Execute()
     if err != nil {
         fmt.Fprintf(os.Stderr, "Error when calling `V0alpha2Api.AdminIdentitySession``: %v\n", err)
         fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
@@ -583,6 +584,7 @@ Other parameters are passed through a pointer to a apiAdminIdentitySessionReques
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
+ **upgrade** | **bool** | Upgrade is a boolean flag that decides, if session should be upgrade to the highest possible level. If no value is provided, session returned is set with AAL1 level. | 
 
 ### Return type
 

--- a/spec/api.json
+++ b/spec/api.json
@@ -2630,6 +2630,72 @@
         ]
       }
     },
+    "/admin/identities/{id}/session": {
+      "get": {
+        "description": "This endpoint is useful for:\n\nIssuing session or session token for a given identity without authenticating",
+        "operationId": "adminIdentitySession",
+        "parameters": [
+          {
+            "description": "ID is the identity's ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Upgrade is a boolean flag that decides, if session should be upgrade to the highest possible level.\nIf no value is provided, session returned is set with AAL1 level.",
+            "in": "query",
+            "name": "upgrade",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/successfulAdminIdentitySession"
+                }
+              }
+            },
+            "description": "successfulAdminIdentitySession"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jsonError"
+                }
+              }
+            },
+            "description": "jsonError"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/jsonError"
+                }
+              }
+            },
+            "description": "jsonError"
+          }
+        },
+        "security": [
+          {
+            "oryAccessToken": []
+          }
+        ],
+        "summary": "Calling this endpoint issues a session for a given identity.",
+        "tags": [
+          "v0alpha2"
+        ]
+      }
+    },
     "/admin/identities/{id}/sessions": {
       "delete": {
         "description": "This endpoint is useful for:\n\nTo forcefully logout Identity from all devices and sessions",
@@ -3219,64 +3285,6 @@
           }
         },
         "summary": "Update Identity Credentials",
-        "tags": [
-          "v0alpha2"
-        ]
-      }
-    },
-    "/identities/{id}/session": {
-      "get": {
-        "description": "This endpoint is useful for:\n\nIssuing session or session token for a given identity without authenticating",
-        "operationId": "adminIdentitySession",
-        "parameters": [
-          {
-            "description": "ID is the identity's ID.",
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/successfulAdminIdentitySession"
-                }
-              }
-            },
-            "description": "successfulAdminIdentitySession"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/jsonError"
-                }
-              }
-            },
-            "description": "jsonError"
-          },
-          "500": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/jsonError"
-                }
-              }
-            },
-            "description": "jsonError"
-          }
-        },
-        "security": [
-          {
-            "oryAccessToken": []
-          }
-        ],
-        "summary": "Calling this endpoint issues a session for a given identity.",
         "tags": [
           "v0alpha2"
         ]

--- a/spec/swagger.json
+++ b/spec/swagger.json
@@ -338,6 +338,60 @@
         }
       }
     },
+    "/admin/identities/{id}/session": {
+      "get": {
+        "security": [
+          {
+            "oryAccessToken": []
+          }
+        ],
+        "description": "This endpoint is useful for:\n\nIssuing session or session token for a given identity without authenticating",
+        "schemes": [
+          "http",
+          "https"
+        ],
+        "tags": [
+          "v0alpha2"
+        ],
+        "summary": "Calling this endpoint issues a session for a given identity.",
+        "operationId": "adminIdentitySession",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "ID is the identity's ID.",
+            "name": "id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "boolean",
+            "description": "Upgrade is a boolean flag that decides, if session should be upgrade to the highest possible level.\nIf no value is provided, session returned is set with AAL1 level.",
+            "name": "upgrade",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successfulAdminIdentitySession",
+            "schema": {
+              "$ref": "#/definitions/successfulAdminIdentitySession"
+            }
+          },
+          "404": {
+            "description": "jsonError",
+            "schema": {
+              "$ref": "#/definitions/jsonError"
+            }
+          },
+          "500": {
+            "description": "jsonError",
+            "schema": {
+              "$ref": "#/definitions/jsonError"
+            }
+          }
+        }
+      }
+    },
     "/admin/identities/{id}/sessions": {
       "get": {
         "security": [
@@ -802,54 +856,6 @@
         "responses": {
           "204": {
             "$ref": "#/responses/emptyResponse"
-          },
-          "404": {
-            "description": "jsonError",
-            "schema": {
-              "$ref": "#/definitions/jsonError"
-            }
-          },
-          "500": {
-            "description": "jsonError",
-            "schema": {
-              "$ref": "#/definitions/jsonError"
-            }
-          }
-        }
-      }
-    },
-    "/identities/{id}/session": {
-      "get": {
-        "security": [
-          {
-            "oryAccessToken": []
-          }
-        ],
-        "description": "This endpoint is useful for:\n\nIssuing session or session token for a given identity without authenticating",
-        "schemes": [
-          "http",
-          "https"
-        ],
-        "tags": [
-          "v0alpha2"
-        ],
-        "summary": "Calling this endpoint issues a session for a given identity.",
-        "operationId": "adminIdentitySession",
-        "parameters": [
-          {
-            "type": "string",
-            "description": "ID is the identity's ID.",
-            "name": "id",
-            "in": "path",
-            "required": true
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "successfulAdminIdentitySession",
-            "schema": {
-              "$ref": "#/definitions/successfulAdminIdentitySession"
-            }
           },
           "404": {
             "description": "jsonError",


### PR DESCRIPTION

## Description
We introduced automatic upgrade for the session, but this should be only enabled behind feature flag as we not always want to have it upgraded all the time.

## Who might be interested?
@Wikia/platform-team 