### PR TITLE
chore (SPLAT-352): pin github actions to commit hash

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Generate SDKs
     runs-on: ubuntu-latest
     steps:
-      - uses: ory/ci/sdk/generate@master
+      - uses: ory/ci/sdk/generate@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
 
@@ -74,7 +74,7 @@ jobs:
           docker start hydra
           docker logs -f hydra &> /tmp/hydra.log &
         name: Start Hydra
-      - uses: ory/ci/checkout@master
+      - uses: ory/ci/checkout@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           fetch-depth: 2
       - uses: actions/setup-go@v4
@@ -82,13 +82,13 @@ jobs:
           go-version: "1.22"
       - run: go list -json > go.list
       - name: Run nancy
-        uses: sonatype-nexus-community/nancy-github-action@v1.0.2
+        uses: sonatype-nexus-community/nancy-github-action@aae196481b961d446f4bff9012e4e3b63d7921a4
         with:
           nancyVersion: v1.0.42
       - run: npm install
         name: Install node deps
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         env:
           GOGC: 100
         with:
@@ -147,7 +147,7 @@ jobs:
             cockroachdb/cockroach:v22.2.6 start-single-node --insecure
           docker start cockroach
         name: Start CockroachDB
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce
         name: Install Chrome
       # - uses: browser-actions/setup-firefox@latest
       #   name: Install Firefox
@@ -155,7 +155,7 @@ jobs:
       #   name: Install Geckodriver
       #   with:
       #     geckodriver-version: 0.32.0
-      - uses: ory/ci/checkout@master
+      - uses: ory/ci/checkout@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           fetch-depth: 2
       - run: |
@@ -258,7 +258,7 @@ jobs:
             cockroachdb/cockroach:v22.2.6 start-single-node --insecure
           docker start cockroach
         name: Start CockroachDB
-      - uses: ory/ci/checkout@master
+      - uses: ory/ci/checkout@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           fetch-depth: 2
       - run: |
@@ -338,7 +338,7 @@ jobs:
     needs:
       - test
     steps:
-      - uses: ory/ci/docs/cli-next@master
+      - uses: ory/ci/docs/cli-next@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
           arg: "."
@@ -352,7 +352,7 @@ jobs:
       - test
       - test-e2e
     steps:
-      - uses: ory/ci/changelog@master
+      - uses: ory/ci/changelog@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
 
@@ -366,7 +366,7 @@ jobs:
       - sdk-generate
       - release
     steps:
-      - uses: ory/ci/sdk/release@master
+      - uses: ory/ci/sdk/release@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
           swag-spec-location: "spec/api.json"
@@ -380,7 +380,7 @@ jobs:
       - test-e2e
       - changelog
     steps:
-      - uses: ory/ci/releaser@master
+      - uses: ory/ci/releaser@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
           goreleaser_key: ${{ secrets.GORELEASER_KEY }}
@@ -395,7 +395,7 @@ jobs:
     needs:
       - release
     steps:
-      - uses: ory/ci/releaser/render-version-schema@master
+      - uses: ory/ci/releaser/render-version-schema@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           token: ${{ secrets.ORY_BOT_PAT }}
           schema-path: .schemastore/config.schema.json
@@ -407,7 +407,7 @@ jobs:
     needs:
       - release
     steps:
-      - uses: ory/ci/newsletter@master
+      - uses: ory/ci/newsletter@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           mailchimp_list_id: f605a41b53
           mailchmip_segment_id: 6479477
@@ -422,7 +422,7 @@ jobs:
     needs:
       - newsletter-draft
     steps:
-      - uses: ory/ci/newsletter/slack-notify@master
+      - uses: ory/ci/newsletter/slack-notify@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -434,7 +434,7 @@ jobs:
     if: ${{ github.ref_type == 'tag' }}
     environment: production
     steps:
-      - uses: ory/ci/newsletter@master
+      - uses: ory/ci/newsletter@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           mailchimp_list_id: f605a41b53
           mailchmip_segment_id: 6479477

--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/setup-node@v2-beta
         with:
           node-version: "14"
-      - uses: ory/closed-reference-notifier@v1
+      - uses: ory/closed-reference-notifier@e389079345c8c974f59bd8ee2869539b41de8252
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issueLabels: upstream,good first issue,help wanted

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
@@ -51,7 +51,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88

--- a/.github/workflows/conventional_commits.yml
+++ b/.github/workflows/conventional_commits.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: config
-        uses: ory/ci/conventional_commit_config@master
+        uses: ory/ci/conventional_commit_config@9955d3e2bde28fe38cb3fae27256c90954721d02
         with:
           config_path: .github/conventional_commits.json
           default_types: |
@@ -46,7 +46,7 @@ jobs:
             deps
             docs
           default_require_scope: false
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/cve-scan.yaml
+++ b/.github/workflows/cve-scan.yaml
@@ -21,15 +21,15 @@ jobs:
         run: |
           echo "SHA_SHORT=$(git rev-parse --short HEAD)" >> "${GITHUB_ENV}"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55
       - name: Build images
         shell: bash
         run: |
           IMAGE_TAG="${{ env.SHA_SHORT }}" make docker
       - name: Anchore Scanner
-        uses: anchore/scan-action@v3
+        uses: anchore/scan-action@3343887d815d7b07465f6fdcd395bd66508d486a
         id: grype-scan
         with:
           image: oryd/kratos:${{ env.SHA_SHORT }}
@@ -45,7 +45,7 @@ jobs:
           echo "::endgroup::"
       - name: Anchore upload scan SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
         with:
           sarif_file: ${{ steps.grype-scan.outputs.sarif }}
       #      - name: Kubescape scanner
@@ -58,7 +58,7 @@ jobs:
       #          image: oryd/kratos:${{ env.SHA_SHORT }}
       #          severityThreshold: critical
       - name: Trivy Scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37
         if: ${{ always() }}
         with:
           image-ref: oryd/kratos:${{ env.SHA_SHORT }}
@@ -69,14 +69,14 @@ jobs:
           severity: "CRITICAL,HIGH"
           scanners: "vuln,secret,config"
       - name: Dockle Linter
-        uses: erzz/dockle-action@v1.3.2
+        uses: erzz/dockle-action@5dea2a0164fd32b38ceef8c8873868bb66b9e395
         if: ${{ always() }}
         with:
           image: oryd/kratos:${{ env.SHA_SHORT }}
           exit-code: 42
           failure-threshold: high
       - name: Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf
         id: hadolint
         if: ${{ always() }}
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Synchronize Issue Labels
-        uses: ory/label-sync-action@v0
+        uses: ory/label-sync-action@f080c2b8ac988f2fc90ddbbc8749c6ee55477f21
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           dry: false

--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -19,12 +19,12 @@ jobs:
         with:
           token: ${{ secrets.TOKEN_PRIVILEGED }}
       - name: Milestone Documentation Generator
-        uses: ory/milestone-action@v0
+        uses: ory/milestone-action@0d8347b062af50e640f1658e8308ba391664d196
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           outputFile: docs/docs/milestones.md
       - name: Commit Milestone Documentation
-        uses: EndBug/add-and-commit@v4.4.0
+        uses: EndBug/add-and-commit@a988073222b8bd50f3ecfca9c0ab7dfbf0d08ceb
         with:
           message: "autogen(docs): update milestone document"
           author_name: aeneasr

--- a/internal/client-go/go.sum
+++ b/internal/client-go/go.sum
@@ -4,6 +4,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI+Ei4I1nO5Jh72wfHlg=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 h1:YUO/7uOKsKeq9UokNS62b8FYywz3ker1l1vDZRCRefw=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use specific commit hashes for all third-party actions instead of default branches or tags. This change improves the security and reliability of the workflows by ensuring that the actions used are immutable and not subject to unexpected changes.